### PR TITLE
Correct Link of Vercel Deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![](https://i.imgur.com/ePJR3zU.jpg)
 
-Despliegue continuo con **vercel now** <https://mcpizzeria.vercel.app>
+Despliegue continuo con **vercel now** <https://mcpizzeria.vercel.app/home>
 
 
 ---


### PR DESCRIPTION
If you enter to the continous deployment link you will never see the project (because the main path is: /home)

I figured out because you mention it in line 17 for the local deploy

So, this commit is for change the public url <https://mcpizzeria.vercel.app> to: <https://mcpizzeria.vercel.app/home>